### PR TITLE
Removed Print statement from the `codeText.swift`

### DIFF
--- a/Sources/HighlightSwift/HighlightViews/CodeText.swift
+++ b/Sources/HighlightSwift/HighlightViews/CodeText.swift
@@ -81,7 +81,6 @@ public struct CodeText {
             }
             await MainActor.run {
                 self.result = result
-                print(result)
                 withAnimation {
                     self.attributedText = result.attributedText
                 }


### PR DESCRIPTION
The print statement is clogging up my console when implementing the `CodeText(_)` view. 

