### PR TITLE
State variable initialize as new state object

### DIFF
--- a/Sources/HighlightSwift/HighlightViews/CodeText.swift
+++ b/Sources/HighlightSwift/HighlightViews/CodeText.swift
@@ -29,8 +29,8 @@ public struct CodeText {
         self.text = text
         self._result = result
         self.showBackground = showBackground
-        self.highlight = Highlight()
-        self.logger = Logger(subsystem: "HighlightSwift", category: "CodeText")
+        self._highlight = State(initialValue: Highlight())
+        self._logger = State(initialValue: Logger(subsystem: "HighlightSwift", category: "CodeText"))
     }
     
     private var attributedText: AttributedString {


### PR DESCRIPTION
State variable should not be initialized by assigning it at init.
Initialization with a new State object is preferable?  Maybe.(Im beginner...)

google translated.  