### PR TITLE
Added `.codeFont(_:)` modifier

### DIFF
--- a/Sources/HighlightSwift/CodeText/CodeText.swift
+++ b/Sources/HighlightSwift/CodeText/CodeText.swift
@@ -7,7 +7,8 @@ public struct CodeText {
     internal var mode: HighlightMode = .automatic
     internal var style: CodeTextStyle = .plain
     internal var colors: CodeTextColors = .theme(.xcode)
-    
+    internal var font: PlatformFont?
+
     internal var success: ((HighlightResult) -> Void)?
     internal var failure: ((Error) -> Void)?
     internal var result: ((Result<HighlightResult, Error>) -> Void)?
@@ -28,7 +29,11 @@ public struct CodeText {
     }
     
     internal var attributedText: AttributedString {
-        highlightResult?.attributedText ?? AttributedString(stringLiteral: text)
+        var attributedText = highlightResult?.attributedText ?? AttributedString(stringLiteral: text)
+        if let font {
+            attributedText.font = font
+        }
+        return attributedText
     }
     
     @MainActor

--- a/Sources/HighlightSwift/CodeText/CodeText.swift
+++ b/Sources/HighlightSwift/CodeText/CodeText.swift
@@ -35,7 +35,15 @@ public struct CodeText {
         }
         return attributedText
     }
-    
+
+    internal var fontDesign: Font.Design? {
+        if font == nil {
+            return .monospaced
+        } else {
+            return nil
+        }
+    }
+
     @MainActor
     internal func highlightText(
         mode: HighlightMode? = nil,

--- a/Sources/HighlightSwift/CodeText/CodeTextModifiers.swift
+++ b/Sources/HighlightSwift/CodeText/CodeTextModifiers.swift
@@ -13,7 +13,14 @@ extension CodeText {
         content.colors = colors
         return content
     }
-    
+
+    /// Sets the font for this code text.
+    public func codeFont(_ font: PlatformFont) -> CodeText {
+        var content = self
+        content.font = font
+        return content
+    }
+
     /// Sets the language detection mode for this code text.
     /// See also `highlightLanguage(_:)` to simply set a language.
     public func highlightMode(_ mode: HighlightMode) -> CodeText {

--- a/Sources/HighlightSwift/CodeText/CodeTextView.swift
+++ b/Sources/HighlightSwift/CodeText/CodeTextView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 extension CodeText: View {
     public var body: some View {
         Text(attributedText)
-            .fontDesign(.monospaced)
+            .fontDesign(fontDesign)
             .padding(.vertical, style.verticalPadding)
             .padding(.horizontal, style.horizontalPadding)
             .background {

--- a/Sources/HighlightSwift/CodeText/PlatformFont.swift
+++ b/Sources/HighlightSwift/CodeText/PlatformFont.swift
@@ -1,0 +1,16 @@
+//
+//  PlatformFont.swift
+//  HighlightSwift
+//
+//  Created by Benjamin Sage on 10/28/24.
+//
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+public typealias PlatformFont = UIFont
+#elseif canImport(AppKit)
+import AppKit
+public typealias PlatformFont = NSFont
+#endif


### PR DESCRIPTION
Updated modifiers to support a `.codeFont(_:)` custom attribute. Disabled monospaced design if font is set custom.